### PR TITLE
apps: add Ollama deployment with NFS-backed model storage

### DIFF
--- a/apps/ollama/deployment.yaml
+++ b/apps/ollama/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      nodeSelector:
+        nvidia.com/gpu: "true"
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports:
+            - containerPort: 11434
+          env:
+            - name: OLLAMA_MODELS
+              value: /models
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+              memory: "16Gi"
+            requests:
+              cpu: "2"
+              memory: "8Gi"
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-models-pvc

--- a/apps/ollama/kustomization.yaml
+++ b/apps/ollama/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - pv.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/ollama/namespace.yaml
+++ b/apps/ollama/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama

--- a/apps/ollama/pv.yaml
+++ b/apps/ollama/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ollama-models-pv
+spec:
+  capacity:
+    storage: 200Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs-ollama
+  nfs:
+    server: 192.0.2.10  # NFS server (Proxmox host)
+    path: /zfs-nvme-data/k8s-storage/ollama

--- a/apps/ollama/pvc.yaml
+++ b/apps/ollama/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-models-pvc
+  namespace: ollama
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-ollama
+  resources:
+    requests:
+      storage: 200Gi

--- a/apps/ollama/service.yaml
+++ b/apps/ollama/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.0.2.201  # MetalLB assigned IP
+  selector:
+    app: ollama
+  ports:
+    - port: 11434
+      targetPort: 11434
+      protocol: TCP

--- a/infra/nfs-storage/kustomization.yaml
+++ b/infra/nfs-storage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+# PV/PVC definitions live with their respective apps.
+# Add shared NFS resources here as needed (e.g. shared datasets).


### PR DESCRIPTION
Ollama configured with GPU scheduling (nvidia.com/gpu), NFS PersistentVolume on ZFS dataset for model storage, and MetalLB LoadBalancer service. Removed local-storage approach in favor of NFS from Proxmox host for cross-pod reusability.