### PR TITLE
docs: update README with storage architecture and Ollama deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,35 @@ A hybrid Kubernetes cluster combining a physical control plane with Proxmox-virt
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                      Kubernetes Cluster                     │
-│                                                             │
-│  ┌──────────────┐     Control Plane (Physical)              │
-│  │  x270-ctrl   │     Lenovo ThinkPad X270                  │
-│  │  (ARM: CP)   │     kubeadm / etcd / API server           │
-│  └──────┬───────┘                                           │
-│         │                                                   │
-│         ├──────────────────────────────────────┐            │
-│         │          Proxmox VE (prox-nix)       │            │
-│         │       AMD Ryzen 3900x · 64GB RAM     │            │
-│         │                                      │            │
-│  ┌──────┴───────┐  ┌──────────────┐  ┌─────────┴────┐       │
-│  │ k8s-gpu-01   │  │k8s-worker-01 │  │k8s-worker-02 │       │
-│  │ RTX 3090     │  │ General      │  │ General      │       │
-│  │ (PCIe Pass)  │  │ Purpose      │  │ Purpose      │       │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-│                                                             │
-│  ┌──────────────┐                                           │
-│  │  TrueNAS     │     NAS (NFS/SMB)                         │
-│  │  Scale       │     Bulk Storage                          │
-│  └──────────────┘                                           │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                      Kubernetes Cluster                      │
+│                                                              │
+│  ┌──────────────┐     Control Plane (Physical)               │
+│  │  x270-ctrl   │     Lenovo ThinkPad X270                   │
+│  │              │     kubeadm / etcd / API server            │
+│  └──────┬───────┘                                            │
+│         │                                                    │
+│         ├───────────────────────────────────────┐            │
+│         │          Proxmox VE (prox-nix)        │            │
+│         │       AMD Ryzen 3900x · 64GB RAM      │            │
+│         │                                       │            │
+│  ┌──────┴───────┐  ┌──────────────┐  ┌──────────┴───┐        │
+│  │ k8s-gpu-01   │  │k8s-worker-01 │  │k8s-worker-02 │        │
+│  │ RTX 3090     │  │ General      │  │ General      │        │ 
+│  │ (PCIe Pass)  │  │ Purpose      │  │ Purpose      │        │
+│  └──────┬───────┘  └──────────────┘  └──────────────┘        │
+│         │                                                    │
+│         │ NFS (model storage)                                │
+│  ┌──────┴───────┐                                            │
+│  │ ZFS on NVMe  │     1TB NVMe — per-app ZFS datasets        │
+│  │ (prox-nix)   │     exported via NFS to cluster            │
+│  └──────────────┘                                            │
+│                                                              │
+│  ┌──────────────┐                                            │
+│  │  TrueNAS     │     NAS (NFS/SMB)                          │
+│  │  Scale       │     Bulk Storage                           │
+│  └──────────────┘                                            │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ## Tech Stack
@@ -40,17 +46,18 @@ A hybrid Kubernetes cluster combining a physical control plane with Proxmox-virt
 | **Orchestration** | Kubernetes v1.31 (kubeadm) |
 | **GPU** | NVIDIA RTX 3090 via VFIO-PCI passthrough |
 | **GPU Runtime** | nvidia-container-toolkit + k8s-device-plugin |
-| **Storage** | TrueNAS Scale (NFS), OpenEBS ZFS-LocalPV (planned) |
+| **Storage** | ZFS on NVMe (NFS export), TrueNAS Scale (NFS) |
 | **Networking** | MetalLB (L2 mode) |
 
 ## Repository Structure
 
 ```
-├── apps/                  # Application workloads
-│   ├── glance/            # Dashboard
-│   └── ollama/            # LLM inference (GPU)
-├── clusters/              # Cluster-wide kustomization
-└── infra/                 # Infrastructure components
+├── apps/                      # Application workloads
+│   ├── glance/                # Dashboard
+│   └── ollama/                # LLM inference (GPU)
+├── clusters/                  # Cluster-wide kustomization
+└── infra/                     # Infrastructure components
+    ├── nfs-storage/           # NFS-backed persistent storage (ZFS)
     └── nvidia-device-plugin/  # GPU scheduling for Kubernetes
 ```
 
@@ -62,9 +69,22 @@ The RTX 3090 is passed from the Proxmox host to the `k8s-gpu-01` VM using VFIO-P
 - **VM**: OVMF/q35 machine type with PCIe passthrough
 - **K8s**: NVIDIA device plugin exposes `nvidia.com/gpu` as a schedulable resource
 
+## Storage
+
+Per-application ZFS datasets on a 1TB NVMe drive, exported via NFS from the Proxmox host to the cluster. Each app gets an isolated dataset for independent snapshots and quota management.
+
+```
+zfs-nvme-data/k8s-storage/
+└── ollama/     # LLM model storage (200Gi PV)
+```
+
+## Running Services
+
+### Ollama (LLM Inference)
+Local large language model inference running on the RTX 3090 (24GB VRAM). Deployed as a Kubernetes workload with GPU scheduling via `nvidia.com/gpu` resource requests. Models are stored on NFS-backed ZFS storage. Accessible across the LAN via MetalLB LoadBalancer on port `11434`.
+
 ## Planned Services
 
 - **Immich** - Self-hosted photo backup with ML-powered search
-- **Ollama** - Local LLM inference on RTX 3090
 - **Grafana + Prometheus** - Cluster observability
 - **Cert Manager** - Automated TLS certificates


### PR DESCRIPTION
Adds ZFS/NFS storage flow to architecture diagram, new Storage section documenting per-app ZFS datasets, and expands Running Services with Ollama deployment details.